### PR TITLE
feat: remove api key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## Version 1.0.5
+
+Update native SDKs to 1.0.5.
+Api key is not needed anymore.
+
 ## Version 1.0.3
 
 Update native SDKs to 1.0.3.

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -55,5 +55,5 @@ android {
 }
 
 dependencies {
-    implementation 'com.github.farly-sdk:farly-android-sdk:1.0.3'
+    implementation 'com.github.farly-sdk:farly-android-sdk:1.0.5'
 }

--- a/android/src/main/java/com/farlysdk/farly_flutter_sdk/FarlyFlutterSdkPlugin.java
+++ b/android/src/main/java/com/farlysdk/farly_flutter_sdk/FarlyFlutterSdkPlugin.java
@@ -57,7 +57,6 @@ public class FarlyFlutterSdkPlugin implements FlutterPlugin, MethodCallHandler, 
     public void onMethodCall(@NonNull MethodCall call, @NonNull Result result) {
         try {
             if (call.method.equals("setup")) {
-                Farly.getInstance().setApiKey(call.argument("apiKey"));
                 Farly.getInstance().setPublisherId(call.argument("publisherId"));
                 result.success("Android " + android.os.Build.VERSION.RELEASE);
             } else if (call.method.equals("getHostedOfferwallUrl")) {

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -31,7 +31,7 @@ class _MyAppState extends State<MyApp> {
   @override
   void initState() {
     super.initState();
-    _farlyFlutterSdkPlugin.setup(apiKey: 'apiKey', publisherId: 'publisherId');
+    _farlyFlutterSdkPlugin.setup(publisherId: 'publisherId');
     if (Platform.isIOS) {
       _farlyFlutterSdkPlugin.requestAdvertisingIdAuthorization();
     }

--- a/ios/Classes/FarlyFlutterSdkPlugin.swift
+++ b/ios/Classes/FarlyFlutterSdkPlugin.swift
@@ -77,12 +77,10 @@ public class FarlyFlutterSdkPlugin: NSObject, FlutterPlugin {
         switch call.method {
         case "setup":
             let args = call.arguments as! [String: Any]
-            guard let apiKey = args["apiKey"] as? String,
-                  let publisherId = args["publisherId"] as? String else {
-                result(FlutterError(code: "setup_error", message: "apiKey and publisherId are mandatory", details: nil))
+            guard let publisherId = args["publisherId"] as? String else {
+                result(FlutterError(code: "setup_error", message: "publisherId are mandatory", details: nil))
                 return
             }
-            Farly.shared.apiKey = apiKey
             Farly.shared.publisherId = publisherId
             
             result(nil)

--- a/ios/farly_flutter_sdk.podspec
+++ b/ios/farly_flutter_sdk.podspec
@@ -4,7 +4,7 @@
 #
 Pod::Spec.new do |s|
   s.name             = 'farly_flutter_sdk'
-  s.version          = '1.0.3'
+  s.version          = '1.0.5'
   s.summary          = 'Farly Flutter SDK'
   s.description      = <<-DESC
 The Farly Flutter SDK is a plugin for Flutter that allows you to integrate the Farly SDK into your Flutter app.
@@ -15,7 +15,7 @@ The Farly Flutter SDK is a plugin for Flutter that allows you to integrate the F
   s.source           = { :path => '.' }
   s.source_files = 'Classes/**/*'
   s.dependency 'Flutter'
-  s.dependency 'Farly', '~> 1.0.3'
+  s.dependency 'Farly', '~> 1.0.5'
   s.platform = :ios, '11.0'
 
   # Flutter.framework does not contain a i386 slice.

--- a/lib/farly_flutter_sdk.dart
+++ b/lib/farly_flutter_sdk.dart
@@ -4,11 +4,10 @@ import 'farly_flutter_sdk_platform_interface.dart';
 import 'feed_element.dart';
 
 class FarlyFlutterSdk {
-  /// Initializes the Farly SDK with the given [apiKey] and [publisherId].
+  /// Initializes the Farly SDK with the given [publisherId].
   /// This method must be called before any other method.
-  Future setup({required String apiKey, required String publisherId}) {
-    return FarlyFlutterSdkPlatform.instance
-        .setup(apiKey: apiKey, publisherId: publisherId);
+  Future setup({required String publisherId}) {
+    return FarlyFlutterSdkPlatform.instance.setup(publisherId: publisherId);
   }
 
   /// Request authorization to use the advertising identifier.

--- a/lib/farly_flutter_sdk_method_channel.dart
+++ b/lib/farly_flutter_sdk_method_channel.dart
@@ -13,9 +13,8 @@ class MethodChannelFarlyFlutterSdk extends FarlyFlutterSdkPlatform {
   final methodChannel = const MethodChannel('farly_flutter_sdk');
 
   @override
-  Future setup({required String apiKey, required String publisherId}) async {
+  Future setup({required String publisherId}) async {
     await methodChannel.invokeMethod('setup', {
-      'apiKey': apiKey,
       'publisherId': publisherId,
     });
   }

--- a/lib/farly_flutter_sdk_platform_interface.dart
+++ b/lib/farly_flutter_sdk_platform_interface.dart
@@ -24,7 +24,7 @@ abstract class FarlyFlutterSdkPlatform extends PlatformInterface {
     _instance = instance;
   }
 
-  Future setup({required String apiKey, required String publisherId}) {
+  Future setup({required String publisherId}) {
     throw UnimplementedError('init() has not been implemented.');
   }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: farly_flutter_sdk
 description: The Farly Flutter SDK is a plugin for Flutter that allows you to integrate the Farly SDK into your Flutter app.
-version: 1.0.3
+version: 1.0.5
 homepage: https://github.com/farly-sdk/farly_flutter_sdk
 
 environment:


### PR DESCRIPTION
passing the apiKey is not required anymore, the publisher id is enough.
